### PR TITLE
Feature/destroy hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The lifecycle of the beans is the following:
 - `init`: The application is initialized, and tasks registered for this phase are executed.
 
 ## Hooks
+
+### Setup
 You can use the `@Setup` hook to add a function that will be executed right after the application is initialized.
 
 ```ts
@@ -120,6 +122,30 @@ mySetupFunction() {
 }
 ```
 Every request received will be served only after the application is initialized and `@Setup` functions are executed.
+
+### Shutdown
+You can use the `@Shutdown` hook to add a function that will be executed right before the application is shutdown.
+
+```ts
+@Shutdown
+myShutdownFunction() {
+  // do something
+}
+```
+
+## Springboot like annotations
+If you want to use Springboot like annotations you can use the following aliases:
+
+- `@PostConstruct` -> `@Setup`
+- `@PreDestroy` -> `@Shutdown`
+- `@Component` -> `@Bean`
+- `@Service` -> `@Bean`
+- `@Controller` -> `@RouterBean`
+- `@Mapping` -> `@Route`
+- `@Autowired` -> `@InjectBean`
+
+## Contribute
+Pull requests or issues/feature requests are welcome!
 
 
 ## License

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 export default {
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
+  coveragePathIgnorePatterns: ['<rootDir>/test/utils'],
   testEnvironment: 'node',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',

--- a/src/core/Executor.spec.ts
+++ b/src/core/Executor.spec.ts
@@ -8,20 +8,76 @@ describe('Executor.ts', () => {
   it.each([
     'start', 'register', 'routing', 'init',
   ] as const)('emits events when a phase is executed: %s', async (phase) => {
+    // GIVEN
     const mock = jest.fn();
     Executor.eventEmitter.on(phase, mock);
+
+    // WHEN
     Executor.startLifecycle();
     await Executor.getExecutionPhase(phase);
+
+    // THEN
     expect(mock).toHaveBeenCalledTimes(1);
   });
 
   it.each([
     'start', 'register', 'routing', 'init',
   ] as const)('execute tasks when a phase is executed: %s', async (phase) => {
+    // GIVEN
     const mock = jest.fn();
     Executor.setExecution(phase, () => mock());
+
+    // WHEN
     Executor.startLifecycle();
     await Executor.getExecutionPhase(phase);
+
+    // THEN
     expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('execute tasks in the defined sequence', async () => {
+    // GIVEN
+    const mock = jest.fn();
+    Executor.setExecution('start', () => mock('start'));
+    Executor.setExecution('register', () => mock('register'));
+    Executor.setExecution('routing', () => mock('routing'));
+    Executor.setExecution('init', () => mock('init'));
+
+    // WHEN
+    Executor.startLifecycle();
+    await Executor.getExecutionPhase('init');
+
+    // THEN
+    expect(mock).toHaveBeenCalledTimes(4);
+    expect(mock).toHaveBeenCalledWith('start');
+    expect(mock).toHaveBeenCalledWith('register');
+    expect(mock).toHaveBeenCalledWith('routing');
+    expect(mock).toHaveBeenCalledWith('init');
+  });
+
+  test('Executor proxy get property', async () => {
+    // GIVEN
+    Executor.setExecution('start', () => {});
+    Executor.setExecution('register', () => {});
+    Executor.setExecution('routing', () => {});
+    Executor.setExecution('init', () => {});
+
+    // THEN
+    expect(Executor.tasks).toEqual(new Map([
+      ['start', [expect.any(Function)]],
+      ['register', [expect.any(Function)]],
+      ['routing', [expect.any(Function)]],
+      ['init', [expect.any(Function)]],
+    ]));
+  });
+
+  it('exposes phases', async () => {
+    // THEN
+    expect(Executor.PHASES).toEqual({
+      0: 'start',
+      1: 'register',
+      2: 'routing',
+      3: 'init',
+    });
   });
 });

--- a/src/core/Executor.spec.ts
+++ b/src/core/Executor.spec.ts
@@ -71,6 +71,38 @@ describe('Executor.ts', () => {
     ]));
   });
 
+  it('execute exit phase', async () => {
+    // GIVEN
+    const mock = jest.fn();
+    Executor.setExecution('exit', () => mock());
+
+    // WHEN
+    Executor.startLifecycle();
+    await Executor.getExecutionPhase('init');
+    Executor.stopLifecycle();
+
+    // THEN
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('executes exit phase on process exit', async () => {
+    // GIVEN
+    const mockExit = jest.spyOn(process, 'exit')
+      .mockImplementationOnce((code?: string | number | null) => process.emit('beforeExit', Number(code)) as never);
+    const mock = jest.fn();
+    Executor.setExecution('exit', () => mock());
+
+    // WHEN
+    Executor.startLifecycle();
+    await Executor.getExecutionPhase('init');
+    process.exit(0);
+
+    // THEN
+    expect(mock).toHaveBeenCalled();
+    expect(mockExit).toHaveBeenCalledWith(0);
+    mockExit.mockRestore();
+  });
+
   it('exposes phases', async () => {
     // THEN
     expect(Executor.PHASES).toEqual({
@@ -78,6 +110,7 @@ describe('Executor.ts', () => {
       1: 'register',
       2: 'routing',
       3: 'init',
+      4: 'exit',
     });
   });
 });

--- a/src/core/Executor.ts
+++ b/src/core/Executor.ts
@@ -40,10 +40,12 @@ class ExecutorImpl {
  * @param phase {ExecutorPhase} phase in which the task should be executed
  */
   setExecution(phase: ExecutorPhase, task: () => Promise<void> | void) {
-    if (!this.tasks.has(phase)) {
-      this.tasks.set(phase, []);
+    let phaseTasks = this.tasks.get(phase);
+    if (!phaseTasks) {
+      phaseTasks = [];
     }
-    this.tasks.get(phase)?.push(task);
+    phaseTasks.push(task);
+    this.tasks.set(phase, phaseTasks);
   }
 
   getExecutionPhase(phase: ExecutorPhase) {
@@ -161,29 +163,5 @@ export const Executor: ExecutorType = new Proxy(ExecutorImpl, {
     }
 
     return value;
-  },
-
-  set(target, prop, value, receiver) {
-    if (prop in target) {
-      return Reflect.set(target, prop, value, receiver);
-    }
-
-    const inst = getInstance();
-    return Reflect.set(inst, prop, value, inst);
-  },
-
-  has(target, prop) {
-    return Reflect.has(target, prop) || Reflect.has(getInstance(), prop);
-  },
-
-  ownKeys(target) {
-    const classKeys = Reflect.ownKeys(target);
-    const instanceKeys = Reflect.ownKeys(getInstance());
-    return [...classKeys, ...instanceKeys];
-  },
-
-  getOwnPropertyDescriptor(target, prop) {
-    return Reflect.getOwnPropertyDescriptor(target, prop)
-           || Reflect.getOwnPropertyDescriptor(getInstance(), prop);
   },
 }) as ExecutorType;

--- a/src/core/ExpressBeans.spec.ts
+++ b/src/core/ExpressBeans.spec.ts
@@ -127,6 +127,26 @@ describe('ExpressBeans.ts', () => {
     mockExit.mockRestore();
   });
 
+  it('emits error event if listen function fails', async () => {
+    // GIVEN
+    const error = new Error('Port already in use');
+    expressMock.listen.mockImplementationOnce((_, cb) => {
+      cb(error);
+    });
+
+    // WHEN
+    const app = await ExpressBeans.createApp();
+    app.on('error', (err) => {
+      expect(err).toBe(error);
+    });
+    await flushPromises();
+    await Executor.getExecutionPhase('init');
+
+    // THEN
+    expect(mockExit).toHaveBeenCalledWith(1);
+    mockExit.mockRestore();
+  });
+
   it('stops the process if listen function fails', async () => {
     // GIVEN
     const error = new Error('Port already in use');

--- a/src/core/decorators/Bean.spec.ts
+++ b/src/core/decorators/Bean.spec.ts
@@ -53,7 +53,7 @@ describe('Bean.ts', () => {
 
     // THEN
     expect(registeredBeans.get('Class')).toBe(C._instance);
-    expect(registeredMethods.get(C._instance.getId)).toBe(C.__target__);
+    expect(registeredMethods.get(C._instance.getId)).toBe(C._instance);
     expect(C._beanUUID).toBeDefined();
     expect(C._className).toBe('Class');
   });

--- a/src/core/decorators/Bean.ts
+++ b/src/core/decorators/Bean.ts
@@ -1,29 +1,6 @@
 import {
   registeredMethods, logger, registeredBeans,
 } from '@/core';
-import { Executor } from '@/core/Executor';
-
-/**
- * Creates a proxy for a class method
- * @param singleton
- * @param classMethod
- */
-const proxyMethod = (singleton: any, classMethod: PropertyKey): void => {
-  logger.debug(`creating proxy for ${singleton._className}.${String(classMethod)}`);
-  Reflect.defineProperty(singleton, classMethod, {
-    value: new Proxy(singleton[classMethod], {
-      get: (instance, actualMethod) => {
-        logger.debug(`proxying ${instance._className}.${String(actualMethod)}`);
-        return async (...args: any[]) => {
-          logger.debug(`Executing ${instance._className}.${String(actualMethod)}`);
-          await Executor.getExecutionPhase('init');
-          const result = await instance[actualMethod](...args);
-          return result;
-        };
-      },
-    }),
-  });
-};
 
 /**
  * Instantiates a new instance of the singleton and registers it
@@ -52,7 +29,6 @@ export function Bean(target: any, _context: ClassDecoratorContext) {
     .forEach((classMethod) => {
       logger.debug(`registering method ${target.name}.${String(classMethod)}`);
       registeredMethods.set(singleton[classMethod], singleton);
-      proxyMethod(singleton, classMethod);
     });
   registeredBeans.set(target.name, singleton);
 }

--- a/src/core/decorators/InjectBean.spec.ts
+++ b/src/core/decorators/InjectBean.spec.ts
@@ -151,4 +151,41 @@ describe('InjectBean.ts', () => {
       expect((instance.dep as any).key).not.toBeDefined();
     }).toThrow(new Error('Cannot get instance for {"key":"value"}: it is not an ExpressBean'));
   });
+
+  it('proxies a dependency', async () => {
+    // GIVEN
+    class TypeA {
+      prop: string = 'value';
+
+      getProp() {
+        return this.prop;
+      }
+    }
+    const T: any = TypeA;
+    T._beanUUID = crypto.randomUUID();
+    T._instance = new TypeA();
+    T._className = TypeA.name;
+
+    // WHEN
+    class Class {
+      @InjectBean(TypeA)
+      private dep: TypeA;
+
+      getDep() {
+        return this.dep;
+      }
+
+      getProp() {
+        return this.dep.getProp();
+      }
+    }
+    const instance = new Class();
+    await flushPromises();
+
+    // THEN
+    expect(isProxy(instance.getDep())).toBe(true);
+    expect((instance.getDep() as any)._beanUUID).toBe(T._beanUUID);
+    expect(instance.getProp()).toBe('value');
+    expect.assertions(3);
+  });
 });

--- a/src/core/decorators/RouterBean.spec.ts
+++ b/src/core/decorators/RouterBean.spec.ts
@@ -40,4 +40,52 @@ describe('RouterBean.ts', () => {
       router,
     });
   });
+
+  it.each([1,2,3,10])('registers a router bean with %s middlewares', async (numberOfMiddlewares: number) => {
+    // GIVEN
+    const router = { use: jest.fn() };
+    express.Router = jest.fn().mockReturnValue(router);
+    const middlewares = new Array(numberOfMiddlewares).fill(jest.fn());
+
+    // WHEN
+    @RouterBean('/route', middlewares)
+    class Class {
+      id = 42;
+    }
+    const C: any = Class;
+    await flushPromises();
+
+    // THEN
+    expect(registeredBeans.get('Class')).toBe(C._instance);
+    expect(C._instance.id).toStrictEqual(42);
+    expect(C._instance._routerConfig).toStrictEqual({
+      path: '/route',
+      router,
+    });
+    expect(router.use).toHaveBeenCalledTimes(1);
+    expect(router.use).toHaveBeenCalledWith(...middlewares);
+  });
+
+  it('registers a router bean with no middlewares', async () => {
+    // GIVEN
+    const router = { use: jest.fn() };
+    express.Router = jest.fn().mockReturnValue(router);
+
+    // WHEN
+    @RouterBean('/route', [])
+    class Class {
+      id = 42;
+    }
+    const C: any = Class;
+    await flushPromises();
+
+    // THEN
+    expect(registeredBeans.get('Class')).toBe(C._instance);
+    expect(C._instance.id).toStrictEqual(42);
+    expect(C._instance._routerConfig).toStrictEqual({
+      path: '/route',
+      router,
+    });
+    expect(router.use).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/decorators/Shutdown.spec.ts
+++ b/src/hooks/decorators/Shutdown.spec.ts
@@ -1,0 +1,73 @@
+import { flushPromises } from '@test/utils/testUtils';
+import { registeredBeans, registeredMethods } from '@/core';
+import { Shutdown } from '@/hooks/decorators/Shutdown';
+import { Executor } from '@/core/Executor';
+
+jest.mock('@/core', () => ({
+  registeredBeans: new Map(),
+  registeredMethods: new Map(),
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('Shutdown.ts', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    registeredMethods.clear();
+    registeredBeans.clear();
+    Executor.stopLifecycle();
+  });
+
+  it('execute a Shutdown function', async () => {
+    // GIVEN
+    const mock = jest.fn();
+    class Class {
+      exited: boolean = false;
+
+      @Shutdown
+      exit() {
+        this.exited = true;
+        mock();
+      }
+    }
+    const bean: any = new Class();
+    registeredMethods.set(bean.exit, bean);
+    registeredBeans.set('Class', bean);
+    await flushPromises();
+    await Executor.execute();
+    await Executor.stopLifecycle();
+
+    // THEN
+    expect(bean.exited)
+      .toBe(true);
+    expect(mock).toHaveBeenCalled();
+  });
+
+  it('execute a Shutdown async function', async () => {
+    // GIVEN
+    const mock = jest.fn();
+    class Class {
+      exited: boolean = false;
+
+      @Shutdown
+      async exit() {
+        this.exited = true;
+        mock();
+      }
+    }
+    const bean: any = new Class();
+    registeredMethods.set(bean.exit, bean);
+    registeredBeans.set('Class', bean);
+    await flushPromises();
+    await Executor.execute();
+    await Executor.stopLifecycle();
+
+    // THEN
+    expect(bean.exited)
+      .toBe(true);
+    expect(mock).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/decorators/Shutdown.ts
+++ b/src/hooks/decorators/Shutdown.ts
@@ -1,0 +1,21 @@
+import { ExpressBean } from '@/ExpressBeansTypes';
+import { logger, registeredMethods } from '@/core';
+import { Executor } from '@/core/Executor';
+
+/**
+   * Hook a function right before the application is destroyed
+   * @decorator
+   */
+export function Shutdown<This>(
+  method: () => any,
+  context: ClassMethodDecoratorContext<This, () => any>,
+) {
+  logger.debug(`Registering pre destroy function ${String(context.name)}`);
+  Executor.setExecution('routing', () => {
+    const bean = registeredMethods.get(method) as ExpressBean;
+    logger.debug(`Initializing ${bean._className}.${String(context.name)} as pre destroy function`);
+    Executor.setExecution('exit', () => method.bind(bean)());
+  });
+
+  return method;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,5 +6,15 @@ export { Route } from '@/core/decorators/Route';
 export { RouterBean } from '@/core/decorators/RouterBean';
 export { InjectLogger } from '@/logging/decorators/InjectLogger';
 export { Setup } from '@/hooks/decorators/Setup';
+export { Shutdown } from '@/hooks/decorators/Shutdown';
 export { Cached } from '@/cache/decorators/Cached';
 export type { Logger } from 'pino';
+
+/* aliases (Springboot like) */
+export { Shutdown as PreDestroy } from '@/hooks/decorators/Shutdown';
+export { Setup as PostConstruct } from '@/hooks/decorators/Setup';
+export { Bean as Component } from '@/core/decorators/Bean';
+export { Bean as Service } from '@/core/decorators/Bean';
+export { RouterBean as Controller } from '@/core/decorators/RouterBean';
+export { Route as Mapping } from '@/core/decorators/Route';
+export { InjectBean as Autowired } from '@/core/decorators/InjectBean';

--- a/test/integration/ExpressBeans.it.spec.ts
+++ b/test/integration/ExpressBeans.it.spec.ts
@@ -75,6 +75,27 @@ describe('ExpressBeans integration tests', () => {
     expect(text).toBe('42 is the answer');
   });
 
+  test('start of application with baseURL', async () => {
+    // GIVEN
+    @RouterBean('/test')
+    class TestRouter {
+      @Route('GET', '/42')
+      test(_req: Request, res: Response) {
+        res.send('42 is the answer');
+      }
+    }
+    application = new ExpressBeans({ listen: false, routerBeans: [TestRouter], baseURL: '/api' });
+    await flushPromises();
+    server = application.listen(3001);
+    await flushPromises();
+
+    // WHEN
+    const { text } = await request(server).get('/api/test/42').expect(200);
+
+    // THEN
+    expect(text).toBe('42 is the answer');
+  });
+
   test('creation of a new application', async () => {
     // WHEN
     application = new ExpressBeans({ listen: false });

--- a/test/utils/testUtils.ts
+++ b/test/utils/testUtils.ts
@@ -2,6 +2,6 @@ export const flushPromises = () => new Promise((resolve) => {
   setImmediate(resolve);
 });
 
-export const fail = (message) => {
+export const fail = (message: string) => {
   throw new Error(message);
 };


### PR DESCRIPTION
- Destroy Hook: `@Shutdown`
The new `@Shutdown` hook allows developers to register functions that will be executed right before the application is shut down. This ensures that resources are properly cleaned up and tasks are completed before the application exits.

- Springboot-like Annotation Aliases
To make ExpressBeans more familiar to Springboot developers, we've introduced the following annotation aliases:
`@PostConstruct` -> `@Setup`
`@PreDestroy` -> `@Shutdown`
`@Component` -> `@Bean`
`@Service` -> `@Bean`
`@Controller` -> `@RouterBean`
`@Mapping` -> `@Route`
`@Autowired` -> `@InjectBean`

These aliases enable developers to use Springboot-like annotations in their ExpressBeans applications, making it easier to get comfortable in ExpressBeans.